### PR TITLE
Update evil-portal.ino - blank the screen to avoid burn-ins

### DIFF
--- a/evil-portal/evil-portal.ino
+++ b/evil-portal/evil-portal.ino
@@ -199,11 +199,12 @@ void loop() {
   if ((millis() - lastTick) > TICK_TIMER) {
 
     lastTick = millis();
-
+    DISPLAY.fillScreen(BLACK);
     if (totalCapturedCredentials != previousTotalCapturedCredentials) {
       previousTotalCapturedCredentials = totalCapturedCredentials;
 
       printHomeToScreen();
+      delayMicroseconds(5000000);
     }
   }
 


### PR DESCRIPTION
With the Cardputer demo software, I noticed a slight burn-in on the screen, when the same image is shown over a rather short period of time.

In order to avoid burn-in when using Evil Portal over a few hours, I added three lines to clear the screen 5 seconds after showing each new captured credencial. This way I hope to extend the life of the screen.